### PR TITLE
Fix podfile

### DIFF
--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'ISMessages', :git => 'https://github.com/EddyVerbruggen/ISMessages.git', :commit => 'dc5d93d2dd282e9ba81fbdeb1a8618a72101ae3f'
+pod 'ISMessages', :git => 'https://github.com/EddyVerbruggen/ISMessages.git', :commit => 'd54b0901bd390164e45adee4e7158122440d10eb'


### PR DESCRIPTION
This resolves an issue, where `pod install` fails because the commit that the podfile refers to is invalid.