### PR TITLE
Add more specific Promise return types.

### DIFF
--- a/src/feedback.android.ts
+++ b/src/feedback.android.ts
@@ -13,7 +13,7 @@ export class Feedback extends FeedbackCommon {
 
   private lastAlert: any = null;
 
-  show(options: FeedbackShowOptions): Promise<any> {
+  show(options: FeedbackShowOptions): Promise<void> {
     return new Promise((resolve, reject) => {
       this.lastAlert = null;
       let alerter = com.tapadoo.alerter.Alerter.create(application.android.foregroundActivity)
@@ -144,7 +144,7 @@ export class Feedback extends FeedbackCommon {
     }
   }
 
-  hide(options?: FeedbackHideOptions): Promise<any> {
+  hide(options?: FeedbackHideOptions): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.lastAlert !== null) {
         this.lastAlert.hide();

--- a/src/feedback.common.ts
+++ b/src/feedback.common.ts
@@ -122,41 +122,41 @@ export interface FeedbackHideOptions {
 }
 
 export interface FeedbackApi {
-  show(options: FeedbackShowOptions): Promise<any>;
+  show(options: FeedbackShowOptions): Promise<void>;
 
-  hide(options?: FeedbackHideOptions): Promise<any>;
+  hide(options?: FeedbackHideOptions): Promise<void>;
 
   // convenience funtions
-  success(options: FeedbackShowOptions): Promise<any>;
+  success(options: FeedbackShowOptions): Promise<void>;
 
-  warning(options: FeedbackShowOptions): Promise<any>;
+  warning(options: FeedbackShowOptions): Promise<void>;
 
-  error(options: FeedbackShowOptions): Promise<any>;
+  error(options: FeedbackShowOptions): Promise<void>;
 
-  info(options: FeedbackShowOptions): Promise<any>;
+  info(options: FeedbackShowOptions): Promise<void>;
 }
 
 export abstract class FeedbackCommon implements FeedbackApi {
-  abstract show(options: FeedbackShowOptions): Promise<any>;
+  abstract show(options: FeedbackShowOptions): Promise<void>;
 
-  abstract hide(options?: FeedbackHideOptions): Promise<any>;
+  abstract hide(options?: FeedbackHideOptions): Promise<void>;
 
-  success(options: FeedbackShowOptions): Promise<any> {
+  success(options: FeedbackShowOptions): Promise<void> {
     options.type = FeedbackType.Success;
     return this.show(options);
   }
 
-  warning(options: FeedbackShowOptions): Promise<any> {
+  warning(options: FeedbackShowOptions): Promise<void> {
     options.type = FeedbackType.Warning;
     return this.show(options);
   }
 
-  error(options: FeedbackShowOptions): Promise<any> {
+  error(options: FeedbackShowOptions): Promise<void> {
     options.type = FeedbackType.Error;
     return this.show(options);
   }
 
-  info(options: FeedbackShowOptions): Promise<any> {
+  info(options: FeedbackShowOptions): Promise<void> {
     options.type = FeedbackType.Info;
     return this.show(options);
   }

--- a/src/feedback.ios.ts
+++ b/src/feedback.ios.ts
@@ -14,7 +14,7 @@ declare const ISMessages, ISAlertPosition, ISAlertType: any;
 
 export class Feedback extends FeedbackCommon {
 
-  show(options: FeedbackShowOptions): Promise<any> {
+  show(options: FeedbackShowOptions): Promise<void> {
     return new Promise((resolve) => {
       let icon: UIImage = options.icon ? UIImage.imageNamed(options.icon) : null;
       let hideOnSwipe: boolean = true;
@@ -75,7 +75,7 @@ export class Feedback extends FeedbackCommon {
     });
   }
 
-  hide(options?: FeedbackHideOptions): Promise<any> {
+  hide(options?: FeedbackHideOptions): Promise<void> {
     return new Promise((resolve) => {
       ISMessages.hideAlertAnimated(true);
       resolve();


### PR DESCRIPTION
Makes feedback methods return types more specific by changing from `Promise<any>` to `Promise<void>`