### PR TITLE
Nativescript-feedback fix feedback.hide promise resolving

### DIFF
--- a/src/feedback.android.ts
+++ b/src/feedback.android.ts
@@ -145,11 +145,13 @@ export class Feedback extends FeedbackCommon {
   }
 
   hide(options?: FeedbackHideOptions): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       if (this.lastAlert !== null) {
         this.lastAlert.hide();
         this.lastAlert = null;
       }
+
+      resolve();
     });
   }
 }


### PR DESCRIPTION
- Fixed the promise resolve on the hide functionality for Android.
- feedback.hide can now successfully be promise chained with show on Android.