### PR TITLE
Added a flag in the feedbackshowoptions object to dictate whether ico…

### DIFF
--- a/src/feedback.android.ts
+++ b/src/feedback.android.ts
@@ -36,10 +36,10 @@ export class Feedback extends FeedbackCommon {
         }
       }
 
-      if(options.android && options.android.iconPulseEnabled) {
+      if (options.android && options.android.iconPulseEnabled) {
         alerter.enableIconPulse(options.android.iconPulseEnabled);
       }
-      
+
       if (options.titleFont) {
         const assetManger = utils.ad.getApplicationContext().getAssets();
         const fontPath = `app/fonts/${options.titleFont}`;

--- a/src/feedback.android.ts
+++ b/src/feedback.android.ts
@@ -36,6 +36,10 @@ export class Feedback extends FeedbackCommon {
         }
       }
 
+      if(options.android && options.android.iconPulseEnabled) {
+        alerter.enableIconPulse(options.android.iconPulseEnabled);
+      }
+      
       if (options.titleFont) {
         const assetManger = utils.ad.getApplicationContext().getAssets();
         const fontPath = `app/fonts/${options.titleFont}`;

--- a/src/feedback.common.ts
+++ b/src/feedback.common.ts
@@ -115,11 +115,11 @@ export interface FeedbackShowOptions {
      * The icon's color. Android only as iOS uses the icon's color, but Android is otherwise always white.
      */
     iconColor?: Color;
-    
+
     /**
      * This dictates whether the icon should pulse, Android only as the icon does not pulse on iOS.
      */
-    iconPulseEnabled?: boolean
+    iconPulseEnabled?: boolean;
   };
 }
 

--- a/src/feedback.common.ts
+++ b/src/feedback.common.ts
@@ -115,6 +115,11 @@ export interface FeedbackShowOptions {
      * The icon's color. Android only as iOS uses the icon's color, but Android is otherwise always white.
      */
     iconColor?: Color;
+    
+    /**
+     * This dictates whether the icon should pulse, Android only as the icon does not pulse on iOS.
+     */
+    iconPulseEnabled?: boolean
   };
 }
 


### PR DESCRIPTION
This is to allow plugin users to disable the pulse on the icon which would allow designs to be consistent across ios and android and for people who dont like the pulse to disable it.