### PR TITLE
fix: Fix for duplicate kotlin versions

### DIFF
--- a/publish/package-lock.json
+++ b/publish/package-lock.json
@@ -1,107 +1,133 @@
 {
   "name": "nativescript-publish",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "balanced-match": {
+  "packages": {
+    "": {
+      "name": "nativescript-publish",
+      "version": "1.0.0",
+      "devDependencies": {
+        "ncp": "^2.0.0",
+        "rimraf": "^2.5.0"
+      }
+    },
+    "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "ncp": {
+    "node_modules/ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "ncp": "bin/ncp"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "rimraf": {
+    "node_modules/rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "glob": "^7.0.5"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",

--- a/src/.npmignore
+++ b/src/.npmignore
@@ -3,4 +3,3 @@
 !feedback.*.d.ts
 !index.d.ts
 tsconfig.json
-platforms/android/res

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-feedback",
-  "version": "3.0.0",
+  "version": "3.0.3",
   "description": "Non-blocking textual feedback for your NativeScript app. AKA superfancy Toasts!",
   "main": "feedback",
   "typings": "index.d.ts",

--- a/src/package.json
+++ b/src/package.json
@@ -1,13 +1,13 @@
 {
   "name": "nativescript-feedback",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Non-blocking textual feedback for your NativeScript app. AKA superfancy Toasts!",
   "main": "feedback",
   "typings": "index.d.ts",
   "nativescript": {
     "platforms": {
-      "android": "7.0.0",
-      "ios": "7.0.0"
+      "android": "8.0.0",
+      "ios": "8.0.0"
     }
   },
   "scripts": {

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -1,6 +1,7 @@
 repositories {
     jcenter()
     mavenCentral()
+    maven { url "https://jitpack.io" }
 }
 
 dependencies {
@@ -13,6 +14,6 @@ dependencies {
         kotlinVer = kotlinVersion
     }
     implementation "com.android.support:appcompat-v7:$supportVer"
-    implementation "com.tapadoo.android:alerter:6.1.0"
+    implementation "com.github.tapadoo:Alerter:7.2.4"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVer"
 }

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -8,7 +8,11 @@ dependencies {
     if (project.hasProperty("supportVersion")) {
         supportVer = supportVersion
     }
+    def kotlinVer = "1.7.10"
+    if (project.hasProperty("kotlinVersion")) {
+        kotlinVer = kotlinVersion
+    }
     implementation "com.android.support:appcompat-v7:$supportVer"
     implementation "com.tapadoo.android:alerter:6.1.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.72"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVer"
 }


### PR DESCRIPTION
Seems this plugin is causing issues when used with NS 8.6.2 in combination with other plugins. We have started getting the following error:
![image](https://github.com/EddyVerbruggen/nativescript-feedback/assets/9464097/bc6a5f9b-aaee-48ef-ad11-e26bedda6a24)
After isolating things, seems was caused by the hardcoded version in the plugin and the usage of the non `jdk8` version of kotlin. 